### PR TITLE
Adding support for dimm_spd and ddr_training_status

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -113,4 +113,6 @@ int cmd_hct_set_config(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_osa_os_patt_trig_cfg(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_osa_misc_trig_cfg(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_osa_data_read(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_dimm_spd_read(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_ddr_training_status(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -169,6 +169,8 @@ static struct cmd_struct commands[] = {
 	{ "osa-os-patt-trig-cfg", .c_fn = cmd_osa_os_patt_trig_cfg },
 	{ "osa-misc-trig-cfg", .c_fn = cmd_osa_misc_trig_cfg },
 	{ "osa-data-read", .c_fn = cmd_osa_data_read },
+	{ "dimm-spd-read", .c_fn = cmd_dimm_spd_read },
+	{ "ddr-training-status", .c_fn = cmd_ddr_training_status },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -166,4 +166,6 @@ global:
 	cxl_memdev_osa_os_patt_trig_cfg;
 	cxl_memdev_osa_misc_trig_cfg;
 	cxl_memdev_osa_data_read;
+	cxl_memdev_dimm_spd_read;
+	cxl_memdev_ddr_training_status;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -232,6 +232,9 @@ int cxl_memdev_osa_misc_trig_cfg(struct cxl_memdev *memdev, u8 cxl_mem_id,
 	u8 trig_en_mask);
 int cxl_memdev_osa_data_read(struct cxl_memdev *memdev, u8 cxl_mem_id,
 	u8 lane_id, u8 lane_dir, u16 start_entry, u8 num_entries);
+int cxl_memdev_dimm_spd_read(struct cxl_memdev *memdev, u32 spd_id,
+	u32 offset, u32 num_bytes);
+int cxl_memdev_ddr_training_status(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \


### PR DESCRIPTION
**Dimm Spd output**
[**********]# ./cxl/cxl dimm-spd-read mem0 -s 0 -o 0 -n 50
=========================== DIMM SPD READ Data ============================
Output Payload:
0000  23 12 0c 01 85 29 00 08 00 60 00 03 08 0b 80 00
0010  00 00 06 0d f8 3f 00 00 6e 6e 6e 11 00 6e f0 0a
0020  20 08 00 05 00 60 18 28 28 00 78 00 14 3c 00 00
0030  00 00

**DDR_TRAINING_STATUS**

[**********]# ./cxl/cxl ddr-training-status mem0
=========================== DDR Training Status ============================
Output Payload:
0000  22 00 21 00 23 00 23 00 21 00 22 00 24 00 23 00
0010  50 00 4e 00 51 00 4f 00 4b 00 4d 00 4c 00 4f 00
0020  38 00 38 00 37 00 35 00 33 00 32 00 33 00 35 00
0030  21 00 20 00 20 00 1e 00 5b 00 5d 00 5e 00 5e 00