### PR TITLE
Add new cxl vendor command to read pmic vtmon info

### DIFF
--- a/cxl/builtin.h
+++ b/cxl/builtin.h
@@ -116,4 +116,5 @@ int cmd_osa_data_read(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_dimm_spd_read(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_ddr_training_status(int argc, const char **argv, struct cxl_ctx *ctx);
 int cmd_dimm_slot_info(int argc, const char **argv, struct cxl_ctx *ctx);
+int cmd_pmic_vtmon_info(int argc, const char **argv, struct cxl_ctx *ctx);
 #endif /* _CXL_BUILTIN_H_ */

--- a/cxl/cxl.c
+++ b/cxl/cxl.c
@@ -172,6 +172,7 @@ static struct cmd_struct commands[] = {
 	{ "dimm-spd-read", .c_fn = cmd_dimm_spd_read },
 	{ "ddr-training-status", .c_fn = cmd_ddr_training_status },
 	{ "dimm-slot-info", .c_fn = cmd_dimm_slot_info },
+	{ "pmic-vtmon-info", .c_fn = cmd_pmic_vtmon_info },
 };
 
 int main(int argc, const char **argv)

--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -169,4 +169,5 @@ global:
 	cxl_memdev_dimm_spd_read;
 	cxl_memdev_ddr_training_status;
     cxl_memdev_dimm_slot_info;
+    cxl_memdev_pmic_vtmon_info;
 } LIBCXL_3;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -236,6 +236,7 @@ int cxl_memdev_dimm_spd_read(struct cxl_memdev *memdev, u32 spd_id,
 	u32 offset, u32 num_bytes);
 int cxl_memdev_ddr_training_status(struct cxl_memdev *memdev);
 int cxl_memdev_dimm_slot_info(struct cxl_memdev *memdev);
+int cxl_memdev_pmic_vtmon_info(struct cxl_memdev *memdev);
 
 #define cxl_memdev_foreach(ctx, memdev) \
         for (memdev = cxl_memdev_get_first(ctx); \

--- a/cxl/memdev.c
+++ b/cxl/memdev.c
@@ -1909,6 +1909,11 @@ static const struct option cmd_dimm_slot_info_options[] = {
   OPT_END(),
 };
 
+static const struct option cmd_pmic_vtmon_info_options[] = {
+  BASE_OPTIONS(),
+  OPT_END(),
+};
+
 static int action_cmd_clear_event_records(struct cxl_memdev *memdev, struct action_context *actx)
 {
   u16 record_handle;
@@ -3463,6 +3468,17 @@ static int action_cmd_dimm_slot_info(struct cxl_memdev *memdev, struct action_co
 	return cxl_memdev_dimm_slot_info(memdev);
 }
 
+static int action_cmd_pmic_vtmon_info(struct cxl_memdev *memdev, struct action_context *actx)
+{
+	if (cxl_memdev_is_active(memdev)) {
+		fprintf(stderr, "%s: memdev active, abort pmic_vtmon_info\n",
+			cxl_memdev_get_devname(memdev));
+		return -EBUSY;
+	}
+
+	return cxl_memdev_pmic_vtmon_info(memdev);
+}
+
 static int action_write(struct cxl_memdev *memdev, struct action_context *actx)
 {
   size_t size = param.len, read_len;
@@ -4525,6 +4541,14 @@ int cmd_dimm_slot_info(int argc, const char **argv, struct cxl_ctx *ctx)
 {
   int rc = memdev_action(argc, argv, ctx, action_cmd_dimm_slot_info, cmd_dimm_slot_info_options,
       "cxl ddr-slot-info <mem0> [<mem1>..<memN>] [<options>]");
+
+  return rc >= 0 ? 0 : EXIT_FAILURE;
+}
+
+int cmd_pmic_vtmon_info(int argc, const char **argv, struct cxl_ctx *ctx)
+{
+  int rc = memdev_action(argc, argv, ctx, action_cmd_pmic_vtmon_info, cmd_pmic_vtmon_info_options,
+      "cxl pmic-vtmon-info <mem0> [<mem1>..<memN>] [<options>]");
 
   return rc >= 0 ? 0 : EXIT_FAILURE;
 }


### PR DESCRIPTION
Add new cxl vendor command to read pmic vtmon info.
Command to read pmic voltage, temperature and power information

=========================== PMIC VTMON SLOT INFO
============================
pmic name: PMIC_VDD_1P8
vin: 11.937500
vout: 1.800000
iout: 0.062500
powr: 0.112500
temp: 38.000000
pmic name: PMIC_VDD_1P2
vin: 11.937500
vout: 1.198047
iout: 1.687500
powr: 2.021704
temp: 38.000000
pmic name: PMIC_VDD_0P8
vin: 11.937500
vout: 0.800000
iout: 1.500000
powr: 1.200000
temp: 37.000000
pmic name: PMIC_DUT_VDDC
vin: 11.968750
vout: 0.850000
iout: 3.437500
powr: 2.921875
temp: 42.500000
pmic name: PMIC_DUT_DDR0_VDDO
vin: 11.984375
vout: 1.200000
iout: 3.125000
powr: 3.750000
temp: 39.250000
pmic name: PMIC_DUT_DDR1_VDDO
vin: 12.000000
vout: 1.200000
iout: 3.125000
powr: 3.750000
temp: 41.750000
pmic name: PMIC_VDD_2P5_DDR0
vin: 11.984375
vout: 2.500000
iout: 0.000000
powr: 0.000000
temp: 41.000000
pmic name: PMIC_VDD_2P5_DDR1
vin: 11.906250
vout: 2.500000
iout: 0.125000
powr: 0.312500
temp: 38.250000